### PR TITLE
[item2]auto: fix typo:cx (fixes #157)

### DIFF
--- a/src/1.DeducingTypes/item2.md
+++ b/src/1.DeducingTypes/item2.md
@@ -30,9 +30,9 @@ const auto cx = x;
 ````
 类型说明符是`const auto`。另一个：
 ````cpp
-const auto & rx=cx;
+const auto& rx = x;
 ````
-类型说明符是`const auto&`。在这里例子中要推导`x`，`rx`和`cx`的类型，编译器的行为看起来就像是认为这里每个声明都有一个模板，然后使用合适的初始化表达式进行调用：
+类型说明符是`const auto&`。在这里例子中要推导`x`，`cx`和`rx`的类型，编译器的行为看起来就像是认为这里每个声明都有一个模板，然后使用合适的初始化表达式进行调用：
 ````cpp
 template<typename T>            //概念化的模板用来推导x的类型
 void func_for_x(T param);

--- a/src/4.SmartPointers/item18.md
+++ b/src/4.SmartPointers/item18.md
@@ -119,7 +119,7 @@ makeInvestment(Ts&&... params)
   };
   ```
 
-在C++14中，函数的返回类型推导存在（参阅[Item3](../1.DeducingTypes/item3.md)），意味着`makeInvestment`可以以更简单，更封装的方式实现：
+在C++14中，函数返回类型推导的存在（参阅[Item3](../1.DeducingTypes/item3.md)），意味着`makeInvestment`可以以更简单，更封装的方式实现：
 
 ```cpp
 template<typename... Ts>
@@ -149,7 +149,7 @@ auto makeInvestment(Ts&&... params)                 //C++14
 }
 ```
 
-我之前说过，当使用默认删除器时（如`delete`），你可以合理假设`std::unique_ptr`对象和原始指针大小相同。当自定义删除器时，情况可能不再如此。函数指针形式的删除器，通常会使`std::unique_ptr`的从一个字（*word*）大小增加到两个。对于函数对象形式的删除器来说，变化的大小取决于函数对象中存储的状态多少，无状态函数（stateless function）对象（比如不捕获变量的*lambda*表达式）对大小没有影响，这意味当自定义删除器可以实现为函数或者*lambda*时，尽量使用*lambda*：
+我之前说过，当使用默认删除器时（如`delete`），你可以合理假设`std::unique_ptr`对象和原始指针大小相同。当自定义删除器时，情况可能不再如此。函数指针形式的删除器，通常会使`std::unique_ptr`的大小从一个字（*word*）增加到两个。对于函数对象形式的删除器来说，变化的大小取决于函数对象中存储的状态多少，无状态函数（stateless function）对象（比如不捕获变量的*lambda*表达式）对大小没有影响，这意味当自定义删除器可以实现为函数或者*lambda*时，尽量使用*lambda*：
 
 ```cpp
 auto delInvmt1 = [](Investment* pInvestment)        //无状态lambda的


### PR DESCRIPTION
const auto& rx = cx;
==>
const auto& rx = x;