### PR TITLE
fix: typo mistake in item32

### DIFF
--- a/src/6.LambdaExpressions/item32.md
+++ b/src/6.LambdaExpressions/item32.md
@@ -69,7 +69,7 @@ private:
     DataType pw;
 };
 
-auto func = IsValAndArch(std::make_unique<Widget>());
+auto func = IsValAndArch(std::make_unique<Widget>())();
 ```
 
 这个代码量比*lambda*表达式要多，但这并不难改变这样一个事实，即如果你希望使用一个C++11的类来支持其数据成员的移动初始化，那么你唯一要做的就是在键盘上多花点时间。


### PR DESCRIPTION
In item32, the example of using self-defined class to take the place of lambda has a typo mistake in using overloaded operator().

The codes are as followed: 

```c
class IsValAndArch {                            //“is validated and archived”
public:
    using DataType = std::unique_ptr<Widget>;
    
    explicit IsValAndArch(DataType&& ptr)       //条款25解释了std::move的使用
    : pw(std::move(ptr)) {}
    
    bool operator()() const
    { return pw->isValidated() && pw->isArchived(); }
    
private:
    DataType pw;
};

auto func = IsValAndArch(std::make_unique<Widget>());

```

Here, the original expression left a `()` out.
```c
auto func = IsValAndArch(std::make_unique<Widget>());
```
should be
```c
auto func = IsValAndArch(std::make_unique<Widget>())();
```