### PR TITLE
Support building books using mdbook in main (v0.5.x)

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["wendajiang"]
 language = "zh"
-multilingual = false
 src = "src"
 title = "Effective Modern C++"
 
@@ -9,4 +8,3 @@ title = "Effective Modern C++"
 mathjax-support = true
 no-section-label = true
 git-repository-url = "https://github.com/CnTransGroup/EffectiveModernCppChinese"
-git-repository-icon = "fa-github"


### PR DESCRIPTION
- The book.multilingual field was removed in https://github.com/rust-lang/mdBook/pull/2775
- The default value for `git-repository-icon` is "fab-github", setting this to "fa-github" will give out error and it's not an valid option